### PR TITLE
chore: add in a .scala-steward.conf file

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,5 @@
+// ignore for now as we target the minimum Gradle version required instead of the newest
+updates.ignore = [
+  { groupId = "org.gradle" },
+  { groupId = "dev.gradleplugins" }
+]


### PR DESCRIPTION
Lock the Gradle version for now as we specifically are including it as the minimum Gradle version