### PR TITLE
Fixes retrieval of `ModuleComponentIdentifier`

### DIFF
--- a/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -62,6 +62,7 @@ import org.gradle.jvm.JvmLibrary
 import org.gradle.language.base.artifact.SourcesArtifact
 import org.gradle.language.java.artifact.JavadocArtifact
 import org.gradle.plugins.ide.internal.tooling.java.DefaultInstalledJdk
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 
 /**
  * Define the conversion from Gradle's project model to Bloop's project model.
@@ -1032,13 +1033,18 @@ class BloopConverter(parameters: BloopParameters) {
       parameters.stdLibName
         .map(List.apply(_))
         .getOrElse(List("scala-library", "scala3-library_3"))
+
     val artifactIds = artifacts
-      .map(_.getId)
-      .collect({ case mcai: ModuleComponentArtifactIdentifier => mcai })
-    val stdLibIds =
-      artifactIds.filter(f => stdLibNames.contains(f.getComponentIdentifier.getModule))
+      .map(_.getId.getComponentIdentifier())
+      .collect {
+        case mid: ModuleComponentIdentifier => mid
+      }
+
+    val stdLibIds = artifactIds
+      .filter(mid => stdLibNames.contains(mid.getModule()))
+
     stdLibIds.headOption match {
-      case Some(stdLibArtifact) =>
+      case Some(stdLibArtifactId) =>
         val scalaCompileTask = sourceSet
           .map(sourceSet => {
             // task name is defined on the source set
@@ -1054,8 +1060,8 @@ class BloopConverter(parameters: BloopParameters) {
 
         scalaCompileTask match {
           case Some(compileTask) =>
-            val scalaVersion = stdLibArtifact.getComponentIdentifier.getVersion
-            val scalaOrg = stdLibArtifact.getComponentIdentifier.getGroup
+            val scalaVersion = stdLibArtifactId.getVersion
+            val scalaOrg = stdLibArtifactId.getGroup
             val scalaJars =
               compileTask.getScalaClasspath.asScala.map(_.toPath).toList
             val opts = compileTask.getScalaCompileOptions
@@ -1105,7 +1111,7 @@ class BloopConverter(parameters: BloopParameters) {
                 .mkString("\n")}"
         Failure(
           new GradleException(
-            s"Expected ${parameters.stdLibName} library in classpath of $target that defines Scala sources.$artifactNames"
+            s"Missing Scala standard library (${stdLibIds}) in classpath of Scala sourceset $target.$artifactNames"
           )
         )
     }

--- a/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -33,6 +33,7 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ArtifactView.ViewConfiguration
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 import org.gradle.api.artifacts.result.ComponentArtifactsResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.Attribute
@@ -62,7 +63,6 @@ import org.gradle.jvm.JvmLibrary
 import org.gradle.language.base.artifact.SourcesArtifact
 import org.gradle.language.java.artifact.JavadocArtifact
 import org.gradle.plugins.ide.internal.tooling.java.DefaultInstalledJdk
-import org.gradle.api.artifacts.component.ModuleComponentIdentifier
 
 /**
  * Define the conversion from Gradle's project model to Bloop's project model.


### PR DESCRIPTION
For some reason, the Bloop plugin wouldn't work at all in a private repository using a proprietary version of Gradle. I believe this is because the presence of a certain plugin that was interfering and changing the artifacts available after resolution to be something else than `ModuleComponentArtifactIdentifier`, so the Scala plugin would never collect the Scala library. But, the result was that the Bloop plugin wouldn't generate Bloop files and it would fail altogether.

The following change, which is untested because I couldn't reproduce, has a fix that uses a more general interface `ModuleComponentIdentifier` and pattern matches on `getComponentIdentifier` instead of the regular artifact identifiers. This seems to be the most correct and general way of writing the previous logic.