### PR TITLE
Adds a Bloop-specific Gradle project configuration

### DIFF
--- a/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -3,15 +3,15 @@ package bloop.integrations.gradle
 import java.io.File
 import java.util.ArrayList
 
+import scala.collection.JavaConverters._
+
 import bloop.integrations.gradle.syntax._
 
 import org.gradle.api.Project
+import org.gradle.api.provider.ListProperty
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
-
-import scala.collection.JavaConverters._
-import org.gradle.api.provider.ListProperty
 
 /**
  * Project extension to configure Bloop.

--- a/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopParameters.scala
@@ -1,6 +1,7 @@
 package bloop.integrations.gradle
 
 import java.io.File
+import java.util.ArrayList
 
 import bloop.integrations.gradle.syntax._
 
@@ -8,6 +9,9 @@ import org.gradle.api.Project
 import org.gradle.api.provider.Property
 import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.Optional
+
+import scala.collection.JavaConverters._
+import org.gradle.api.provider.ListProperty
 
 /**
  * Project extension to configure Bloop.
@@ -21,6 +25,7 @@ import org.gradle.api.tasks.Optional
  *   stdLibName = "scala-library" // or "scala3-library_3"
  *   includeSources = true
  *   includeJavaDoc = false
+ *   extendUserConfigurations = ["myCustomMainConfig"]
  * }
  * }}}
  */
@@ -58,6 +63,13 @@ case class BloopParametersExtension(project: Project) {
   @Input @Optional def getIncludeJavadoc: Property[java.lang.Boolean] =
     includeJavadoc_
 
+  private val extendUserConfigurations_ : ListProperty[String] =
+    project.getObjects().listProperty(classOf[String])
+  extendUserConfigurations_.set(new ArrayList[String]())
+
+  @Input @Optional def getExtendUserConfigurations: ListProperty[String] =
+    extendUserConfigurations_
+
   def createParameters: BloopParameters = {
     val defaultTargetDir =
       project.getRootProject.workspacePath.resolve(".bloop").toFile
@@ -66,7 +78,8 @@ case class BloopParametersExtension(project: Project) {
       Option(compilerName_.getOrNull),
       Option(stdLibName_.getOrNull),
       includeSources_.get,
-      includeJavadoc_.get
+      includeJavadoc_.get,
+      extendUserConfigurations_.get.asScala.toList
     )
   }
 }
@@ -76,5 +89,6 @@ case class BloopParameters(
     compilerName: Option[String],
     stdLibName: Option[String],
     includeSources: Boolean,
-    includeJavadoc: Boolean
+    includeJavadoc: Boolean,
+    extendUserConfigurations: List[String]
 )

--- a/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -56,7 +56,8 @@ final class BloopPlugin extends Plugin[Project] {
     "incrementalScalaAnalysisElements",
     "incrementalScalaAnalysisFormain",
     "incrementalScalaAnalysisFortest",
-    "incrementalScalaAnalysisForintegtest",
+    "incrementalScalaAnalysisForintegTest",
+    "incrementalScalaAnalysisForjmh",
     "zinc"
   )
 

--- a/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -53,7 +53,6 @@ final class BloopPlugin extends Plugin[Project] {
           config != bloopConfig && config.isCanBeResolved &&
           !incompatibleConfigurations.contains(config.getName())
         ) {
-          println(s"Extending ${config.getName()} from BloopConfig")
           bloopConfig.extendsFrom(config)
         }
       }

--- a/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -1,11 +1,14 @@
 package bloop.integrations.gradle
 
 import bloop.integrations.gradle.syntax._
+import bloop.integrations.gradle.tasks.PluginUtils
 import bloop.integrations.gradle.tasks.BloopInstallTask
 import bloop.integrations.gradle.tasks.ConfigureBloopInstallTask
+import scala.collection.JavaConverters._
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.tasks.SourceSet
 import org.gradle.api.artifacts.Configuration
 
 /**
@@ -27,9 +30,84 @@ final class BloopPlugin extends Plugin[Project] {
       s"Applying bloop plugin to project ${project.getName}",
       Seq.empty: _*
     )
+
     project.createExtension[BloopParametersExtension]("bloop", project)
 
-    val bloopConfig = project.getConfigurations().create("bloopConfig")
+    project.afterEvaluate(
+      new org.gradle.api.Action[Project] {
+        def execute(project: Project): Unit = {
+
+          val bloopParams = project.getExtension[BloopParametersExtension].createParameters
+
+          if (PluginUtils.hasJavaScalaPlugin(project)) {
+            project.allSourceSets.foreach { sourceSet =>
+              val bloopConfigName = generateBloopConfigName(sourceSet)
+              val bloopConfig = createBloopConfigForSourceSet(bloopConfigName, project)
+              val compatibleConfigNames =
+                findCompatibleConfigNamesFromSourceSet(sourceSet) ++
+                  bloopParams.extendUserConfigurations
+
+              extendCompatibleConfigurationAfterEvaluate(
+                project,
+                bloopConfig,
+                compatibleConfigNames,
+                Set.empty
+              )
+            }
+          }
+
+          if (PluginUtils.hasAndroidPlugin(project)) {
+            // In the Android world, we don't have source sets for each variant, so instead
+            // we create an Android-specific configuration that we can use to resolve all
+            // relevant artifacts in all variants (the empty extend configs)
+            val bloopAndroidConfig = createBloopConfigForSourceSet("bloopAndroidConfig", project)
+
+            extendCompatibleConfigurationAfterEvaluate(
+              project,
+              bloopAndroidConfig,
+              Set.empty,
+              incompatibleAndroidConfigurations
+            )
+          }
+        }
+      }
+    )
+
+    // Creates two tasks: one to configure the plugin and the other one to generate the config files
+    val configureBloopInstall =
+      project.createTask[ConfigureBloopInstallTask]("configureBloopInstall")
+    val bloopInstall = project.createTask[BloopInstallTask]("bloopInstall")
+    configureBloopInstall.installTask = Some(bloopInstall)
+    bloopInstall.dependsOn(configureBloopInstall)
+    ()
+  }
+
+  private def findCompatibleConfigNamesFromSourceSet(sourceSet: SourceSet): Set[String] = Set(
+    sourceSet.getApiConfigurationName(),
+    sourceSet.getImplementationConfigurationName(),
+    sourceSet.getCompileOnlyConfigurationName(),
+    // sourceSet.getCompileOnlyApiConfigurationName(),
+    sourceSet.getCompileClasspathConfigurationName(),
+    sourceSet.getRuntimeOnlyConfigurationName(),
+    sourceSet.getRuntimeClasspathConfigurationName(),
+    sourceSet.getRuntimeElementsConfigurationName(),
+    "scalaCompilerPlugins"
+  )
+
+  private[this] val incompatibleAndroidConfigurations = Set[String](
+    "incrementalScalaAnalysisElements",
+    "incrementalScalaAnalysisFormain",
+    "incrementalScalaAnalysisFortest",
+    "incrementalScalaAnalysisForintegTest",
+    "incrementalScalaAnalysisForjmh",
+    "zinc"
+  )
+
+  private def createBloopConfigForSourceSet(
+      bloopConfigName: String,
+      project: Project
+  ): Configuration = {
+    val bloopConfig = project.getConfigurations().create(bloopConfigName)
     bloopConfig.setDescription(
       "A configuration for Bloop to be able to export artifacts in all other configurations."
     )
@@ -41,50 +119,34 @@ final class BloopPlugin extends Plugin[Project] {
     // This configuration is not meant to be consumed by other projects
     bloopConfig.setCanBeConsumed(false)
 
-    extendCompatibleConfigurationAfterEvaluate(project, bloopConfig)
-
-    // Creates two tasks: one to configure the plugin and the other one to generate the config files
-    val configureBloopInstall =
-      project.createTask[ConfigureBloopInstallTask]("configureBloopInstall")
-    val bloopInstall = project.createTask[BloopInstallTask]("bloopInstall")
-    configureBloopInstall.installTask = Some(bloopInstall)
-    bloopInstall.dependsOn(configureBloopInstall)
-    ()
+    bloopConfig
   }
 
-  private[this] val incompatibleConfigurations = Set[String](
-    "incrementalScalaAnalysisElements",
-    "incrementalScalaAnalysisFormain",
-    "incrementalScalaAnalysisFortest",
-    "incrementalScalaAnalysisForintegTest",
-    "incrementalScalaAnalysisForjmh",
-    "zinc"
-  )
-
-  def extendCompatibleConfigurationAfterEvaluate(
+  /**
+   * Makes the input configuration extend valid compatible configurations.
+   * Note that if extendConfigNames is empty, all resolvable and non-whitelisted
+   * configurations will be extended automatically.
+   */
+  private def extendCompatibleConfigurationAfterEvaluate(
       project: Project,
-      bloopConfig: Configuration
+      bloopSourceSetConfig: Configuration,
+      compatibleConfigNames: Set[String],
+      incompatibleConfigNames: Set[String]
   ): Unit = {
     // Use consumer instead of Scala closure because of Scala 2.11 compat
     val extendConfigurationIfCompatible = new java.util.function.Consumer[Configuration] {
       def accept(config: Configuration): Unit = {
         if (
-          config != bloopConfig && config.isCanBeResolved &&
-          !incompatibleConfigurations.contains(config.getName())
+          config != bloopSourceSetConfig &&
+          config.isCanBeResolved &&
+          (compatibleConfigNames.isEmpty || compatibleConfigNames.contains(config.getName())) &&
+          !incompatibleConfigNames.contains(config.getName())
         ) {
-          bloopConfig.extendsFrom(config)
+          bloopSourceSetConfig.extendsFrom(config)
         }
       }
     }
 
-    // Important to do this after evaluation so Gradle can add all the necessary project configuration before we extend them
-    project.afterEvaluate(
-      // Use Action instead of Scala closure because of Scala 2.11 compat
-      new org.gradle.api.Action[Project] {
-        def execute(project: Project): Unit = {
-          project.getConfigurations.forEach(extendConfigurationIfCompatible)
-        }
-      }
-    )
+    project.getConfigurations.forEach(extendConfigurationIfCompatible)
   }
 }

--- a/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -6,6 +6,7 @@ import bloop.integrations.gradle.tasks.ConfigureBloopInstallTask
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.artifacts.Configuration
 
 /**
  * Main entry point of the gradle bloop plugin.
@@ -48,7 +49,7 @@ final class BloopPlugin extends Plugin[Project] {
     )
 
     project.afterEvaluate { (project: Project) =>
-      project.getConfigurations.forEach { config =>
+      project.getConfigurations.forEach { (config: Configuration) =>
         if (
           config != bloopConfig && config.isCanBeResolved &&
           !incompatibleConfigurations.contains(config.getName())

--- a/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
+++ b/src/main/scala/bloop/integrations/gradle/BloopPlugin.scala
@@ -1,15 +1,16 @@
 package bloop.integrations.gradle
 
+import scala.collection.JavaConverters._
+
 import bloop.integrations.gradle.syntax._
-import bloop.integrations.gradle.tasks.PluginUtils
 import bloop.integrations.gradle.tasks.BloopInstallTask
 import bloop.integrations.gradle.tasks.ConfigureBloopInstallTask
-import scala.collection.JavaConverters._
+import bloop.integrations.gradle.tasks.PluginUtils
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
-import org.gradle.api.tasks.SourceSet
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.tasks.SourceSet
 
 /**
  * Main entry point of the gradle bloop plugin.

--- a/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -191,13 +191,23 @@ class BloopConverter(parameters: BloopParameters) {
         targetDir
       )
 
+      val bloopConfig = project.getConfiguration("bloopConfig")
+      val allArtifacts = getConfigurationArtifacts(bloopConfig)
+
       // get all configurations dependencies - these go into the resolutions as the user can create their own config dependencies (e.g. compiler plugin jar)
       // some configs aren't allowed to be resolved - hence the catch
       // this can bring too many artifacts into the resolution section (e.g. junit on main projects) but there's no way to know which artifact is required by which sourceset
       // filter out internal scala plugin configurations
-      val allArtifacts = project.getConfigurations.asScala
-        .filter(_.isCanBeResolved)
-        .flatMap(getConfigurationArtifacts)
+
+      //     val allArtifacts2 = project.getConfigurations.asScala
+      //       .filter(_.isCanBeResolved)
+      //       .flatMap(getConfigurationArtifacts)
+
+      //   System.out.println(s"""
+      //   |All artifacts (new): $allArtifacts
+      //   |All artifacts (old): $allArtifacts2
+      //   """.stripMargin)
+
       val additionalModules = allArtifacts
         .filterNot(f => allOutputsToSourceSets.contains(f.getFile))
         .map(artifactToConfigModule(_, project))
@@ -355,17 +365,8 @@ class BloopConverter(parameters: BloopParameters) {
       // some configs aren't allowed to be resolved - hence the catch
       // this can bring too many artifacts into the resolution section (e.g. junit on main projects) but there's no way to know which artifact is required by which sourceset
       // filter out internal scala plugin configurations
-      val modules = project.getConfigurations.asScala
-        .filter(_.isCanBeResolved)
-        .filter(c =>
-          !List(
-            "incrementalScalaAnalysisElements",
-            "incrementalScalaAnalysisFormain",
-            "incrementalScalaAnalysisFortest",
-            "zinc"
-          ).contains(c.getName)
-        )
-        .flatMap(getConfigurationArtifacts)
+      val bloopConfig = project.getConfiguration("bloopConfig")
+      val modules = getConfigurationArtifacts(bloopConfig)
         .filter(f =>
           !allArchivesToSourceSets.contains(f.getFile) &&
             !allOutputDirsToSourceSets.contains(f.getFile)

--- a/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -65,6 +65,7 @@ import org.gradle.language.java.artifact.JavadocArtifact
 import org.gradle.plugins.ide.internal.tooling.java.DefaultInstalledJdk
 import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ProjectComponentIdentifier
+import org.gradle.api.specs.Spec
 
 /**
  * Define the conversion from Gradle's project model to Bloop's project model.
@@ -432,14 +433,16 @@ class BloopConverter(parameters: BloopParameters) {
         override def execute(viewConfig: ViewConfiguration): Unit = {
           viewConfig
             .lenient(true)
-            .componentFilter { (id: ComponentIdentifier) =>
-              // Filter out project dependencies as we're not interested in them
-              // Furthermore, if there are any configuration transforms Gradle
-              // must check that the artifact jars are present, and if we depend
-              // on project dependencies then it'll fail because project
-              // dependencies don't have existing jars at the time of resolution
-              !(id.isInstanceOf[ProjectComponentIdentifier])
-            }
+            .componentFilter(new Spec[ComponentIdentifier] {
+              def isSatisfiedBy(id: ComponentIdentifier): Boolean = {
+                // Filter out project dependencies as we're not interested in them
+                // Furthermore, if there are any configuration transforms Gradle
+                // must check that the artifact jars are present, and if we depend
+                // on project dependencies then it'll fail because project
+                // dependencies don't have existing jars at the time of resolution
+                !(id.isInstanceOf[ProjectComponentIdentifier])
+              }
+            })
             .attributes(new Action[AttributeContainer] {
               override def execute(
                   attributeContainer: AttributeContainer

--- a/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -33,7 +33,9 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.artifacts.ArtifactView.ViewConfiguration
 import org.gradle.api.artifacts.Configuration
+import org.gradle.api.artifacts.component.ComponentIdentifier
 import org.gradle.api.artifacts.component.ModuleComponentIdentifier
+import org.gradle.api.artifacts.component.ProjectComponentIdentifier
 import org.gradle.api.artifacts.result.ComponentArtifactsResult
 import org.gradle.api.artifacts.result.ResolvedArtifactResult
 import org.gradle.api.attributes.Attribute
@@ -51,6 +53,7 @@ import org.gradle.api.internal.tasks.compile.JavaCompilerArgumentsBuilder
 import org.gradle.api.plugins.JavaApplication
 import org.gradle.api.provider.Property
 import org.gradle.api.provider.Provider
+import org.gradle.api.specs.Spec
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.compile.CompileOptions
@@ -63,9 +66,6 @@ import org.gradle.jvm.JvmLibrary
 import org.gradle.language.base.artifact.SourcesArtifact
 import org.gradle.language.java.artifact.JavadocArtifact
 import org.gradle.plugins.ide.internal.tooling.java.DefaultInstalledJdk
-import org.gradle.api.artifacts.component.ComponentIdentifier
-import org.gradle.api.artifacts.component.ProjectComponentIdentifier
-import org.gradle.api.specs.Spec
 
 /**
  * Define the conversion from Gradle's project model to Bloop's project model.

--- a/src/main/scala/bloop/integrations/gradle/syntax.scala
+++ b/src/main/scala/bloop/integrations/gradle/syntax.scala
@@ -123,4 +123,12 @@ object syntax {
   implicit class FileExtension(file: File) {
     def /(child: String): File = new File(file, child)
   }
+
+  def capitalize(x: String): String = Option(x) match {
+    case Some(s) if s.nonEmpty => s.head.toUpper + s.tail
+    case _ => x
+  }
+
+  def generateBloopConfigName(sourceSet: SourceSet): String =
+    s"bloop${capitalize(sourceSet.getName())}Config"
 }

--- a/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -3632,6 +3632,7 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
         |
         |configurations {
         |    scalaCompilerPlugin
+        |    bloopConfig.extendsFrom(scalaCompilerPlugin)
         |}
         |
         |dependencies {

--- a/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -3632,7 +3632,10 @@ abstract class ConfigGenerationSuite extends BaseConfigSuite {
         |
         |configurations {
         |    scalaCompilerPlugin
-        |    bloopConfig.extendsFrom(scalaCompilerPlugin)
+        |}
+        |
+        |bloop {
+        |    extendUserConfigurations = [configurations.scalaCompilerPlugin.name]
         |}
         |
         |dependencies {


### PR DESCRIPTION
Some Gradle experts at $WORK have told me that the way we were
previously resolving artifacts wasn't strictly correct due to two reasons:

- Project references in project configurations (like the ones we resolve
  in `getConfigurationArtifacts`) are allowed to be empty for now, but
  that will change, and it's a bug. https://github.com/gradle/gradle/issues/26155

- The way we currently resolve artifacts doesn't let Gradle know our
  intention (as we can resolve any arbitrary configuration) and it
  doesn't play well with Gradle transforms, which require all of the
  resolved configuration artifacts to be present, otherwise it fails
  with a `FileNotFoundException`.

As a result, I changed the code to introduce a Gradle configuration
`bloopConfig` that extends all those configurations we care about, and
change the resolution code to only depend on that configuration.

It seems that solution works and passes all tests, and it avoids the
`FileNotFoundException` error I found out.

Because we now have a proper `configuration`, it means that users that
create their own configuration and want it to be exported to bloop need
to do `bloopConfig.extendsFrom(myConfig)` where `myConfig` is a
user-defined configuration. The reason for this is because when we
declare that our configuration extends all the other existing
configuration, we do it at evaluation time. User-defined configurations
run after the bloop plugin, so they never get added unless the user
wishes to. This is not a big deal as custom configuration are extremely
rare, and this is a common practice in Gradle land when you define your
own configuration.