### PR TITLE
Support Gradle 9 and Java 25 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java: [ '11', '17' ]
+        java: [ '11', '17', '21', '25' ]
         os: [ 'ubuntu-latest' ]
 
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -35,7 +35,7 @@ lazy val V = new {
   val androidGradle = "8.7.3"
   val bloopConfig = "1.5.5"
   val classgraph = "4.8.180"
-  val gradle = "5.0"
+  val gradle = "5.1"
   val groovy = "3.0.25"
   val junitInterface = "0.13.3"
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,9 @@ ThisBuild / scalafixDependencies += "com.github.liancheng" %% "organize-imports"
 ThisBuild / semanticdbVersion := scalafixSemanticdb.revision
 ThisBuild / semanticdbEnabled := true
 
+Test / parallelExecution := true
+Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a")
+
 lazy val V = new {
   val androidGradle = "8.7.3"
   val bloopConfig = "1.5.5"
@@ -55,7 +58,6 @@ lazy val plugin = (project in file("."))
       case Some((2, 13)) => "-Wunused"
       case _ => ""
     }),
-    testOptions += Tests.Argument(TestFrameworks.JUnit, "-v", "-a"),
     libraryDependencies ++= List(
       "dev.gradleplugins" % "gradle-api" % V.gradle % Provided,
       "dev.gradleplugins" % "gradle-test-kit" % V.gradle % Provided,

--- a/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
+++ b/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala
@@ -580,7 +580,7 @@ class BloopConverter(parameters: BloopParameters) {
       archiveTask <- tasksWithType(project, classOf[AbstractArchiveTask])
       sourcePathObj <- getSourcePaths(archiveTask.getRootSpec())
       sourcePath <- sourceSets.find(_.getOutput == sourcePathObj)
-    } yield archiveTask.getArchivePath -> sourcePath
+    } yield archiveTask.getArchiveFile.get.getAsFile -> sourcePath
     archiveSourceSets.toMap
   }
 

--- a/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -32,8 +32,8 @@ import org.junit.rules.TemporaryFolder
  */
 
 // minimum supported version
-class ConfigGenerationSuite_5_0 extends ConfigGenerationSuite {
-  protected def gradleVersion: String = "5.0"
+class ConfigGenerationSuite_5_1 extends ConfigGenerationSuite {
+  protected def gradleVersion: String = "5.1.1"
 }
 
 // kept to test Gradle API changes

--- a/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
+++ b/src/test/scala/bloop/integrations/gradle/ConfigGenerationSuite.scala
@@ -38,7 +38,7 @@ class ConfigGenerationSuite_5_1 extends ConfigGenerationSuite {
 
 // kept to test Gradle API changes
 class ConfigGenerationSuite_7_5 extends ConfigGenerationSuite {
-  protected def gradleVersion: String = "7.5"
+  protected def gradleVersion: String = "7.5.1"
 }
 
 // maximum supported version


### PR DESCRIPTION
This PR adds support for Gradle 9. Gradle 9 requires Java 17+ to run, whereas Gradle 8.14 does not support Java 25.

**Summary of changes:**

1. Replace the removed deprecated [`getArchivePath`](https://docs.gradle.org/5.1/javadoc/org/gradle/api/tasks/bundling/AbstractArchiveTask.html#getArchivePath()) in Gradle 9 with `getArchiveFile.get.getAsFile`.
https://github.com/scalacenter/gradle-bloop/blob/1b2cfc2ba5fa4831cea2fb3ece96f88cd946a5c2/src/main/scala/bloop/integrations/gradle/model/BloopConverter.scala#L583
2. Raise minimum Gradle version from 5.0 to 5.1 to support `getArchiveFile`.
3. Update `SemVer` comparison to allow optional patch numbers, easing wildcard version ranges in the Gradle compatibility matrix.
4. Fix `generateConfigFileForJavaOnlyProjects` test to work with both `mainClassName` and `mainClass`.
5. Update Gradle 7.5 → 7.5.1 since 7.5 is unavailable at https://services.gradle.org/distributions/.
6. Enable CI builds on Java LTS 17 and 25.
